### PR TITLE
flake: replace gomod2nix input with amarbel-llc/nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775908449,
-        "narHash": "sha256-36vFfhwO74im3A5f7fyIIJVUT70m4RZynmzVy1l55Vo=",
+        "lastModified": 1776891116,
+        "narHash": "sha256-jF9rEPahajLrpbwculYu5SN2t+Ebd93dD8hoCnPUNeA=",
         "owner": "amarbel-llc",
         "repo": "bob",
-        "rev": "cd445fe928084ba7219aa48a50ff7c7d3f5bbaf0",
+        "rev": "1b5a0c57f302996c26c1af0093d4867fc7304e93",
         "type": "github"
       },
       "original": {
@@ -42,7 +42,7 @@
           "purse-first",
           "crane"
         ],
-        "gomod2nix": "gomod2nix_4",
+        "gomod2nix": "gomod2nix_3",
         "nixpkgs": [
           "madder",
           "nixpkgs"
@@ -82,7 +82,7 @@
           "crane"
         ],
         "fh": "fh_3",
-        "gomod2nix": "gomod2nix_8",
+        "gomod2nix": "gomod2nix_7",
         "nixpkgs": [
           "madder",
           "tommy",
@@ -124,7 +124,7 @@
           "crane"
         ],
         "fh": "fh_5",
-        "gomod2nix": "gomod2nix_12",
+        "gomod2nix": "gomod2nix_11",
         "nixpkgs": [
           "tommy",
           "nixpkgs"
@@ -603,24 +603,6 @@
         "type": "github"
       }
     },
-    "flake-utils_10": {
-      "inputs": {
-        "systems": "systems_13"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_2"
@@ -677,7 +659,7 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -731,7 +713,7 @@
     },
     "flake-utils_8": {
       "inputs": {
-        "systems": "systems_10"
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -774,47 +756,20 @@
         ]
       },
       "locked": {
-        "lastModified": 1770585520,
-        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
-        "owner": "nix-community",
+        "lastModified": 1775655738,
+        "narHash": "sha256-fK9KNU9oNugFyGu8uqv1OM4anYFVcIeYVntuaUFx4Y0=",
+        "owner": "amarbel-llc",
         "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "rev": "c721288259a04d29966f38d5baa3d3b30bf8fe08",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "amarbel-llc",
         "repo": "gomod2nix",
         "type": "github"
       }
     },
     "gomod2nix_10": {
-      "inputs": {
-        "flake-utils": [
-          "madder",
-          "tommy",
-          "utils"
-        ],
-        "nixpkgs": [
-          "madder",
-          "tommy",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770585520,
-        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
-    "gomod2nix_11": {
       "inputs": {
         "flake-utils": [
           "purse-first",
@@ -839,9 +794,9 @@
         "type": "github"
       }
     },
-    "gomod2nix_12": {
+    "gomod2nix_11": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": [
           "tommy",
           "bob",
@@ -862,9 +817,9 @@
         "type": "github"
       }
     },
-    "gomod2nix_13": {
+    "gomod2nix_12": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": [
           "tommy",
           "bob",
@@ -886,7 +841,7 @@
         "type": "github"
       }
     },
-    "gomod2nix_14": {
+    "gomod2nix_13": {
       "inputs": {
         "flake-utils": [
           "tommy",
@@ -938,27 +893,6 @@
       "inputs": {
         "flake-utils": "flake-utils_3",
         "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775655738,
-        "narHash": "sha256-fK9KNU9oNugFyGu8uqv1OM4anYFVcIeYVntuaUFx4Y0=",
-        "owner": "amarbel-llc",
-        "repo": "gomod2nix",
-        "rev": "c721288259a04d29966f38d5baa3d3b30bf8fe08",
-        "type": "github"
-      },
-      "original": {
-        "owner": "amarbel-llc",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
-    "gomod2nix_4": {
-      "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": [
           "madder",
           "bob",
           "nixpkgs"
@@ -978,9 +912,9 @@
         "type": "github"
       }
     },
-    "gomod2nix_5": {
+    "gomod2nix_4": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "madder",
           "bob",
@@ -1002,9 +936,9 @@
         "type": "github"
       }
     },
-    "gomod2nix_6": {
+    "gomod2nix_5": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "madder",
           "nixpkgs-master"
@@ -1024,7 +958,7 @@
         "type": "github"
       }
     },
-    "gomod2nix_7": {
+    "gomod2nix_6": {
       "inputs": {
         "flake-utils": [
           "madder",
@@ -1051,9 +985,9 @@
         "type": "github"
       }
     },
-    "gomod2nix_8": {
+    "gomod2nix_7": {
       "inputs": {
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "madder",
           "tommy",
@@ -1075,9 +1009,9 @@
         "type": "github"
       }
     },
-    "gomod2nix_9": {
+    "gomod2nix_8": {
       "inputs": {
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_7",
         "nixpkgs": [
           "madder",
           "tommy",
@@ -1100,10 +1034,37 @@
         "type": "github"
       }
     },
+    "gomod2nix_9": {
+      "inputs": {
+        "flake-utils": [
+          "madder",
+          "tommy",
+          "utils"
+        ],
+        "nixpkgs": [
+          "madder",
+          "tommy",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
     "madder": {
       "inputs": {
         "bob": "bob_2",
-        "gomod2nix": "gomod2nix_6",
+        "gomod2nix": "gomod2nix_5",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1115,11 +1076,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776529135,
-        "narHash": "sha256-1+1xpqmGbAXxspgDZgY0n0kGicKWBQuOZNfFiktK+xc=",
+        "lastModified": 1776865583,
+        "narHash": "sha256-RQmwTdJ2K8tMYtD/wA8YUTISd6pjqAR4xcXgH9abNR8=",
         "owner": "amarbel-llc",
         "repo": "madder",
-        "rev": "7afe2302f40365ec313f9a29cace93b56a03efc8",
+        "rev": "6384fabccd0c5ea40fd33e02e776597341ff852c",
         "type": "github"
       },
       "original": {
@@ -1406,17 +1367,16 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
-        "owner": "NixOS",
+        "lastModified": 1776962920,
+        "narHash": "sha256-bYtlNzLdsIhdZC7MfH6MdGwAF3HDcn7o/zskSDU1vZQ=",
+        "owner": "amarbel-llc",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "20cb1a3c58be8a8298c28ee2e7eaacb0f6cfa4e0",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "amarbel-llc",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
         "type": "github"
       }
     },
@@ -1448,7 +1408,7 @@
       "inputs": {
         "crane": "crane_3",
         "fh": "fh_2",
-        "gomod2nix": "gomod2nix_5",
+        "gomod2nix": "gomod2nix_4",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-master": "nixpkgs-master_2",
         "rust-overlay": "rust-overlay_3",
@@ -1471,7 +1431,7 @@
     "purse-first_3": {
       "inputs": {
         "crane": "crane_5",
-        "gomod2nix": "gomod2nix_7",
+        "gomod2nix": "gomod2nix_6",
         "nixpkgs": [
           "madder",
           "nixpkgs"
@@ -1504,7 +1464,7 @@
       "inputs": {
         "crane": "crane_7",
         "fh": "fh_4",
-        "gomod2nix": "gomod2nix_9",
+        "gomod2nix": "gomod2nix_8",
         "nixpkgs": "nixpkgs_7",
         "nixpkgs-master": "nixpkgs-master_4",
         "rust-overlay": "rust-overlay_6",
@@ -1527,7 +1487,7 @@
     "purse-first_5": {
       "inputs": {
         "crane": "crane_9",
-        "gomod2nix": "gomod2nix_11",
+        "gomod2nix": "gomod2nix_10",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1557,7 +1517,7 @@
       "inputs": {
         "crane": "crane_11",
         "fh": "fh_6",
-        "gomod2nix": "gomod2nix_13",
+        "gomod2nix": "gomod2nix_12",
         "nixpkgs": "nixpkgs_12",
         "nixpkgs-master": "nixpkgs-master_7",
         "rust-overlay": "rust-overlay_9",
@@ -1580,7 +1540,6 @@
     "root": {
       "inputs": {
         "bob": "bob",
-        "gomod2nix": "gomod2nix_3",
         "madder": "madder",
         "nixpkgs": "nixpkgs_9",
         "nixpkgs-master": "nixpkgs-master_6",
@@ -2004,21 +1963,6 @@
         "type": "github"
       }
     },
-    "systems_15": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "systems_2": {
       "locked": {
         "lastModified": 1681028828,
@@ -2142,7 +2086,7 @@
     "tommy": {
       "inputs": {
         "bob": "bob_3",
-        "gomod2nix": "gomod2nix_10",
+        "gomod2nix": "gomod2nix_9",
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-master": "nixpkgs-master_5",
         "utils": [
@@ -2167,7 +2111,7 @@
     "tommy_2": {
       "inputs": {
         "bob": "bob_4",
-        "gomod2nix": "gomod2nix_14",
+        "gomod2nix": "gomod2nix_13",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -2179,11 +2123,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775399611,
-        "narHash": "sha256-ElzACYuPmWpNk7bm4V8de18P+PqG+92X9aSxJg8gRUI=",
+        "lastModified": 1776866155,
+        "narHash": "sha256-qrauTqWjBz1AXtfa98cSBCu2W0azPJcun11vPwInRMo=",
         "owner": "amarbel-llc",
         "repo": "tommy",
-        "rev": "87255e87bf372148f2b17a5514eb73f8a84e0ac4",
+        "rev": "b138d1f32ae6a5f5ea21721a0ad4c27d7aae1832",
         "type": "github"
       },
       "original": {
@@ -2211,7 +2155,7 @@
     },
     "utils_2": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -2228,7 +2172,7 @@
     },
     "utils_3": {
       "inputs": {
-        "systems": "systems_11"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -2245,7 +2189,7 @@
     },
     "utils_4": {
       "inputs": {
-        "systems": "systems_14"
+        "systems": "systems_13"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -2262,7 +2206,7 @@
     },
     "utils_5": {
       "inputs": {
-        "systems": "systems_15"
+        "systems": "systems_14"
       },
       "locked": {
         "lastModified": 1731533236,

--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,11 @@
           CGO_ENABLED = "0";
         };
 
+        goEnv = pkgs.mkGoEnv {
+          pwd = ./.;
+          go = pkgs-master.go_1_26;
+        };
+
         maneater =
           pkgs.runCommand "maneater-wrapped"
             {
@@ -184,6 +189,7 @@
 
         devShells.default = pkgs-master.mkShell {
           packages = [
+            goEnv
             pkgs-master.go_1_26
             pkgs-master.gopls
             pkgs-master.gotools

--- a/flake.nix
+++ b/flake.nix
@@ -58,28 +58,13 @@
 
         go = pkgs-master.go_1_26;
 
-        # Fetch a GGUF embedding model by name, URL, and sha256. The sha256 may
-        # be in any format builtins.convertHash accepts: hex, base16, base32,
-        # base64, or SRI (sha256-<base64>). HuggingFace shows hex on file pages.
-        fetchGgufModel =
-          { name, url, sha256 }:
-          pkgs.fetchurl {
-            inherit url;
-            name = "${name}.gguf";
-            hash = builtins.convertHash {
-              hash = sha256;
-              hashAlgo = "sha256";
-              toHashFormat = "sri";
-            };
-          };
-
-        nomic-model = fetchGgufModel {
+        nomic-model = pkgs.fetchGgufModel {
           name = "nomic-embed-text-v1.5-Q8_0";
           url = "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q8_0.gguf";
           sha256 = "sha256-PiQ0IWSz2UmRupaS/cDdCOP9c2Lgqsw5appcVKVEw7c=";
         };
 
-        snowflake-model = fetchGgufModel {
+        snowflake-model = pkgs.fetchGgufModel {
           name = "snowflake-arctic-embed-l-v2.0-q8_0";
           url = "https://huggingface.co/Casual-Autopsy/snowflake-arctic-embed-l-v2.0-gguf/resolve/main/snowflake-arctic-embed-l-v2.0-q8_0.gguf";
           sha256 = "sha256-C+gyDssPtuIF8KFBnOPUaINLxE0Cy/2l/RcbNoGxJZc=";
@@ -127,36 +112,41 @@
             && !(pkgs.lib.hasInfix "/.tmp/" path);
         };
 
-        maneater-unwrapped = pkgs.buildGoApplication {
-          pname = "maneater";
-          version = "0.6.0";
+        goAppBase = {
+          inherit go;
           src = goSrc;
-          subPackages = [ "cmd/maneater" ];
           modules = ./gomod2nix.toml;
-          go = go;
           GOTOOLCHAIN = "local";
-          CGO_ENABLED = "1";
-          nativeBuildInputs = [ pkgs.pkg-config ];
-          buildInputs = [ pkgs.llama-cpp ];
         };
+
+        maneater-unwrapped = pkgs.buildGoApplication (
+          goAppBase
+          // {
+            pname = "maneater";
+            version = "0.6.0";
+            subPackages = [ "cmd/maneater" ];
+            CGO_ENABLED = "1";
+            nativeBuildInputs = [ pkgs.pkg-config ];
+            buildInputs = [ pkgs.llama-cpp ];
+          }
+        );
 
         # maneater-man is the lean companion binary the default manpages
         # corpus spawns per page. No CGO, no llama-cpp, no llama init cost
         # on every subprocess. See maneater#12 / #17.
-        maneater-man-unwrapped = pkgs.buildGoApplication {
-          pname = "maneater-man";
-          version = "0.6.0";
-          src = goSrc;
-          subPackages = [ "cmd/maneater-man" ];
-          modules = ./gomod2nix.toml;
-          go = go;
-          GOTOOLCHAIN = "local";
-          CGO_ENABLED = "0";
-        };
+        maneater-man-unwrapped = pkgs.buildGoApplication (
+          goAppBase
+          // {
+            pname = "maneater-man";
+            version = "0.6.0";
+            subPackages = [ "cmd/maneater-man" ];
+            CGO_ENABLED = "0";
+          }
+        );
 
         goEnv = pkgs.mkGoEnv {
           pwd = ./.;
-          go = go;
+          inherit go;
         };
 
         maneater =
@@ -186,8 +176,6 @@
           inherit maneater maneater-unwrapped maneater-man-unwrapped;
           default = maneater;
         };
-
-        lib = { inherit fetchGgufModel; };
 
         devShells.default = pkgs-master.mkShell {
           packages = [

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,8 @@
           inherit system;
         };
 
+        go = pkgs-master.go_1_26;
+
         # Fetch a GGUF embedding model by name, URL, and sha256. The sha256 may
         # be in any format builtins.convertHash accepts: hex, base16, base32,
         # base64, or SRI (sha256-<base64>). HuggingFace shows hex on file pages.
@@ -131,7 +133,7 @@
           src = goSrc;
           subPackages = [ "cmd/maneater" ];
           modules = ./gomod2nix.toml;
-          go = pkgs-master.go_1_26;
+          go = go;
           GOTOOLCHAIN = "local";
           CGO_ENABLED = "1";
           nativeBuildInputs = [ pkgs.pkg-config ];
@@ -147,14 +149,14 @@
           src = goSrc;
           subPackages = [ "cmd/maneater-man" ];
           modules = ./gomod2nix.toml;
-          go = pkgs-master.go_1_26;
+          go = go;
           GOTOOLCHAIN = "local";
           CGO_ENABLED = "0";
         };
 
         goEnv = pkgs.mkGoEnv {
           pwd = ./.;
-          go = pkgs-master.go_1_26;
+          go = go;
         };
 
         maneater =
@@ -170,7 +172,7 @@
                     pkgs.mandoc
                     pkgs.pandoc
                     pkgs.tldr
-                    pkgs-master.go_1_26
+                    go
                     madder.packages.${system}.default
                     maneater-man-unwrapped
                   ]
@@ -190,7 +192,6 @@
         devShells.default = pkgs-master.mkShell {
           packages = [
             goEnv
-            pkgs-master.go_1_26
             pkgs-master.gopls
             pkgs-master.gotools
             pkgs-master.golangci-lint

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,9 @@
   description = "Maneater: man page search index and semantic search CLI";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/4590696c8693fea477850fe379a01544293ca4e2";
+    nixpkgs.url = "github:amarbel-llc/nixpkgs";
     nixpkgs-master.url = "github:NixOS/nixpkgs/e2dde111aea2c0699531dc616112a96cd55ab8b5";
     utils.url = "https://flakehub.com/f/numtide/flake-utils/0.1.102";
-
-    gomod2nix = {
-      url = "github:amarbel-llc/gomod2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
 
     tommy = {
       url = "github:amarbel-llc/tommy";
@@ -45,7 +40,6 @@
       nixpkgs,
       nixpkgs-master,
       utils,
-      gomod2nix,
       tommy,
       bob,
       madder,
@@ -56,9 +50,6 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [
-            gomod2nix.overlays.default
-          ];
         };
 
         pkgs-master = import nixpkgs-master {
@@ -199,7 +190,6 @@
             pkgs-master.golangci-lint
             pkgs-master.delve
             pkgs-master.gofumpt
-            gomod2nix.packages.${system}.default
             pkgs.just
             pkgs.llama-cpp
             pkgs.pandoc


### PR DESCRIPTION
## What

Replaces the `amarbel-llc/gomod2nix` flake input + overlay with `amarbel-llc/nixpkgs`, which now ships `buildGoApplication`, `mkGoEnv`, `mkVendorEnv`, and `mkGoCacheEnv` as flat `pkgs` attributes.

## Why

`buildGoApplication` and friends are now vendored directly into the nixpkgs fork (see `pkgs/build-support/gomod2nix/`). Downstream repos no longer need a separate gomod2nix flake input — nixpkgs is the only source of truth.

## Changes

- `nixpkgs` input points to `amarbel-llc/nixpkgs` instead of upstream NixOS/nixpkgs
- `gomod2nix` flake input removed
- `gomod2nix.overlays.default` overlay removed — no longer needed
- `gomod2nix.packages.${system}.default` (CLI) removed from devShell — it is an implementation detail of lockfile generation, not needed for normal development

## Verified

Both packages built successfully against the new input locally:
- `nix build .#maneater-man-unwrapped` ✓
- `nix build .#maneater-unwrapped` ✓

🤡 Clown — https://github.com/amarbel-llc/clown